### PR TITLE
remove useless preg_quote

### DIFF
--- a/src/Bouda/Php7Backport/DirectoryBackporter.php
+++ b/src/Bouda/Php7Backport/DirectoryBackporter.php
@@ -24,7 +24,7 @@ class DirectoryBackporter
 
         foreach ($iterator as $file)
         {
-            $newPath = preg_replace("#^" . preg_quote($sourceDir) . "#", preg_quote($destinationDir), $file);
+            $newPath = preg_replace("#^" . preg_quote($sourceDir) . "#", $destinationDir, $file);
 
             if ($file->isDir() && !file_exists($newPath))
             {


### PR DESCRIPTION
using preg_quote on the replacement parameter of preg_match is useless
and it cause bugs as it puts backslashes in front of some characters
that can be presents in path like - or : on Windows