### PR TITLE
Remove scalar aliases and iterable

### DIFF
--- a/src/Bouda/Php7Backport/Visitor/ScalarTypehint.php
+++ b/src/Bouda/Php7Backport/Visitor/ScalarTypehint.php
@@ -19,7 +19,7 @@ use PhpParser\Node\Param;
  */
 class ScalarTypehint extends Php7Backport\Visitor
 {
-    const INVALID_TYPE_HINTS = [
+    private static $INVALID_TYPE_HINTS = [
         'int',
         'float',
         'double',
@@ -34,7 +34,7 @@ class ScalarTypehint extends Php7Backport\Visitor
     {
         if ($node instanceof Param
             && isset($node->type->parts[0])
-            && in_array($node->type->parts[0], self::INVALID_TYPE_HINTS))
+            && in_array($node->type->parts[0], self::$INVALID_TYPE_HINTS, true))
         {
             return $this->tranformAndSave($node);
         }

--- a/src/Bouda/Php7Backport/Visitor/ScalarTypehint.php
+++ b/src/Bouda/Php7Backport/Visitor/ScalarTypehint.php
@@ -12,18 +12,29 @@ use PhpParser\Node\Param;
 /**
  * Remove scalar typehint from function or method parameter.
  *
- * Example: 
+ * Example:
  * function foo(string $x, SomeClass $y) {...
  * becomes
  * function foo($x, SomeClass $y) {...
  */
 class ScalarTypehint extends Php7Backport\Visitor
 {
+    const INVALID_TYPE_HINTS = [
+        'int',
+        'float',
+        'double',
+        'string',
+        'bool',
+        'boolean',
+        'iterable',
+    ];
+
+
     public function leaveNode(Node $node)
     {
         if ($node instanceof Param
-            && isset($node->type->parts[0]) 
-            && in_array($node->type->parts[0], ['int', 'float', 'string', 'bool']))
+            && isset($node->type->parts[0])
+            && in_array($node->type->parts[0], self::INVALID_TYPE_HINTS))
         {
             return $this->tranformAndSave($node);
         }

--- a/tests/functional/ScalarTypehintTest.php
+++ b/tests/functional/ScalarTypehintTest.php
@@ -5,10 +5,27 @@ require_once __DIR__ . '/BackporterFunctionalTestAbstract.php';
 
 class ScalarTypehintTest extends BackporterFunctionalTestAbstract
 {
-    public function testScalarTypeHint()
+    /**
+     * @dataProvider invalidTypeHintProvider
+     */
+    public function testScalarTypeHint(string $typeHint)
     {
-        $code = '<?php function foo(string $x, SomeClass $y) {}';
+        $code = '<?php function foo(' . $typeHint . ' $x, SomeClass $y) {}';
         $expected = '<?php function foo($x, SomeClass $y) {}';
         $this->assertEquals($expected, $this->backporter->port($code));
+    }
+
+
+    public function invalidTypeHintProvider() : array
+    {
+        return [
+            ['float'],
+            ['double'],
+            ['string'],
+            ['int'],
+            ['bool'],
+            ['boolean'],
+            ['iterable'],
+        ];
     }
 }

--- a/tests/functional/ScalarTypehintTest.php
+++ b/tests/functional/ScalarTypehintTest.php
@@ -8,7 +8,7 @@ class ScalarTypehintTest extends BackporterFunctionalTestAbstract
     /**
      * @dataProvider invalidTypeHintProvider
      */
-    public function testScalarTypeHint(string $typeHint)
+    public function testScalarTypeHint($typeHint)
     {
         $code = '<?php function foo(' . $typeHint . ' $x, SomeClass $y) {}';
         $expected = '<?php function foo($x, SomeClass $y) {}';
@@ -16,7 +16,7 @@ class ScalarTypehintTest extends BackporterFunctionalTestAbstract
     }
 
 
-    public function invalidTypeHintProvider() : array
+    public function invalidTypeHintProvider()
     {
         return [
             ['float'],


### PR DESCRIPTION
Hey there,

I started working on something similar and after implementing a couple of backports I found your project. Thanks for the effort!

I added checks for the scalar aliases `boolean` and `double` (which I would prefer to never ever see, but some people still use ...) and for the PHP 7.1 `iterable`.

Cheers,
Mike

P.S. more PRs coming in the next few days (if you're interested)