### PR TITLE
Add 7.1 to Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
 
 install:
   - composer install


### PR DESCRIPTION
7.1 is the new stable version, so I added it to the Travis CI config file to make sure we're also future-proof :smile: 